### PR TITLE
Proposal: allow filtering by full filename

### DIFF
--- a/tlc/walk.go
+++ b/tlc/walk.go
@@ -285,7 +285,7 @@ func WalkDir(basePathIn string, opts WalkOpts) (*Container, error) {
 			// don't end up with files we (the patcher) can't modify
 			Mode := fileInfo.Mode() | ModeMask
 
-			if filter(fileInfo.Name()) == FilterIgnore {
+			if filter(FullPath) == FilterIgnore {
 				if Mode.IsDir() {
 					return filepath.SkipDir
 				}


### PR DESCRIPTION
:wave: lake maintainers!

Apologies in advance for opening a PR against this repo, I understand it might not be the intended.

Fact is, I am implementing a `wharf`-based Linux container distribution tool, and in the context of that project I need to filter the subset of files to sync.

Currently, I can specify a `lake/tlc.FilterFunc` as parameter to `WalkDir`, to get a neat `Container` with the subset of files I need. Except that currently, `lake` only passes the file name to `filter`, and not the whole path.

For my use case (allow/deny listing) the mere filename is not sufficient, I need the whole path.

Questions now:
 - would it be possible to accept a PR like this one in `lake` to allow `wharf` users to cover this case?
 - is the approach I took here too crude?

Thanks in advance!